### PR TITLE
GET /resources should not 404 if no resources

### DIFF
--- a/brood/resources/actions.py
+++ b/brood/resources/actions.py
@@ -137,7 +137,7 @@ def get_list_of_resources(
     application_id: Optional[str] = None,
 ) -> List[models.Resource]:
     """
-    Return list of available resource to user. 
+    Return list of available resource to user.
     """
     query = (
         db_session.query(models.Resource)
@@ -158,10 +158,6 @@ def get_list_of_resources(
         query = query.filter(models.Resource.resource_data[key].astext == value)
 
     resources = query.all()
-    if len(resources) == 0:
-        raise exceptions.ResourceNotFound(
-            f"Did not found resources for user with id: {user_id}"
-        )
 
     return resources
 

--- a/brood/resources/api.py
+++ b/brood/resources/api.py
@@ -105,7 +105,7 @@ async def create_resource_handler(
     Create the resource.
     Current user will inherit all permissions to the resource.
 
-    - **data** (dict): 
+    - **data** (dict):
         - **application_id** (uuid)
         - **resource_data** (dict)
     """
@@ -150,8 +150,6 @@ async def get_resources_list_handler(
         resources = actions.get_list_of_resources(
             db_session, current_user.id, user_groups_ids, params, application_id
         )
-    except exceptions.ResourceNotFound:
-        raise HTTPException(status_code=404, detail="Resources not found")
     except Exception as err:
         logger.error(f"Unhandled error in get_resources_list_handler: {str(err)}")
         raise HTTPException(status_code=500)


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Returning a 404 on a list endpoint makes client-side logic unnecessarily complicated. This PR changes the API so that it simply returns an empty list if there were no resources found.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Tested manually.

Before commit:
```bash
curl -H "Authorization: Bearer <token>" "localhost:7474/resources/"
# Response: {"detail":"Resources not found"}
```

After commit:
```bash
curl -H "Authorization: Bearer <token>" "localhost:7474/resources/"
# Response: {"resources":[]}
```

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
